### PR TITLE
feat: glamourによるMarkdownレンダリング機能を追加

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -57,7 +57,6 @@ func runInteractive(cmd *cobra.Command, args []string) error {
 		return nil // User cancelled
 	}
 
-	// Get the selected plan
 	selectedPlan, err := repo.Get(result.Name)
 	if err != nil {
 		return fmt.Errorf("プランの取得に失敗しました: %w", err)
@@ -69,7 +68,6 @@ func runInteractive(cmd *cobra.Command, args []string) error {
 	case fzf.ActionDelete:
 		return deletePlan(repo, result.Name)
 	default:
-		// ActionShow - Show the selected plan
 		content, err := repo.GetContent(result.Name)
 		if err != nil {
 			return fmt.Errorf("プランの読み取りに失敗しました: %w", err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -17,61 +17,40 @@ func TestPlansDir(t *testing.T) {
 }
 
 func TestPager_Default(t *testing.T) {
-	// t.Setenv captures original value for cleanup, then we unset
 	t.Setenv("PAGER", "")
 	os.Unsetenv("PAGER")
-	t.Cleanup(func() {
-		// t.Setenv's cleanup will restore original value
-	})
-	p := Pager()
-	if p != DefaultPager {
-		t.Errorf("Pager() = %q, want %q", p, DefaultPager)
+
+	if got := Pager(); got != DefaultPager {
+		t.Errorf("Pager() = %q, want %q", got, DefaultPager)
 	}
 }
 
 func TestPager_EnvOverride(t *testing.T) {
 	t.Setenv("PAGER", "more")
-	p := Pager()
-	if p != "more" {
-		t.Errorf("Pager() = %q, want 'more'", p)
+
+	if got := Pager(); got != "more" {
+		t.Errorf("Pager() = %q, want 'more'", got)
 	}
 }
 
 func TestEditor_Default(t *testing.T) {
 	t.Setenv("EDITOR", "")
 	os.Unsetenv("EDITOR")
-	t.Cleanup(func() {})
-	e := Editor()
-	if e != "vim" {
-		t.Errorf("Editor() = %q, want 'vim'", e)
+
+	if got := Editor(); got != "vim" {
+		t.Errorf("Editor() = %q, want 'vim'", got)
 	}
 }
 
 func TestEditor_EnvOverride(t *testing.T) {
 	t.Setenv("EDITOR", "nano")
-	e := Editor()
-	if e != "nano" {
-		t.Errorf("Editor() = %q, want 'nano'", e)
+
+	if got := Editor(); got != "nano" {
+		t.Errorf("Editor() = %q, want 'nano'", got)
 	}
 }
 
-func TestRawMarkdown_Unset(t *testing.T) {
-	t.Setenv("CC_PLANS_RAW", "")
-	os.Unsetenv("CC_PLANS_RAW")
-	t.Cleanup(func() {})
-	if RawMarkdown() {
-		t.Error("RawMarkdown() = true, want false when CC_PLANS_RAW is unset")
-	}
-}
-
-func TestRawMarkdown_Enabled(t *testing.T) {
-	t.Setenv("CC_PLANS_RAW", "1")
-	if !RawMarkdown() {
-		t.Error("RawMarkdown() = false, want true when CC_PLANS_RAW=1")
-	}
-}
-
-func TestRawMarkdown_OtherValues(t *testing.T) {
+func TestRawMarkdown(t *testing.T) {
 	tests := []struct {
 		value string
 		unset bool
@@ -89,13 +68,12 @@ func TestRawMarkdown_OtherValues(t *testing.T) {
 			name = "CC_PLANS_RAW=<unset>"
 		}
 		t.Run(name, func(t *testing.T) {
-			t.Setenv("CC_PLANS_RAW", "")
 			if tt.unset {
+				t.Setenv("CC_PLANS_RAW", "")
 				os.Unsetenv("CC_PLANS_RAW")
 			} else {
-				os.Setenv("CC_PLANS_RAW", tt.value)
+				t.Setenv("CC_PLANS_RAW", tt.value)
 			}
-			t.Cleanup(func() {})
 			if got := RawMarkdown(); got != tt.want {
 				t.Errorf("RawMarkdown() = %v, want %v", got, tt.want)
 			}

--- a/internal/fzf/fzf.go
+++ b/internal/fzf/fzf.go
@@ -104,19 +104,19 @@ func Select(plans []plan.Plan) (SelectResult, error) {
 	}
 
 	// Extract just the name (first field before tab)
-	parts := strings.Split(selection, "\t")
-	name := parts[0]
+	name := strings.Split(selection, "\t")[0]
 
-	// Determine action based on key pressed
-	var action Action
+	return SelectResult{Name: name, Action: actionFromKey(key)}, nil
+}
+
+// actionFromKey maps an fzf --expect key to an Action.
+func actionFromKey(key string) Action {
 	switch key {
 	case "ctrl-e":
-		action = ActionEdit
+		return ActionEdit
 	case "ctrl-d":
-		action = ActionDelete
+		return ActionDelete
 	default:
-		action = ActionShow
+		return ActionShow
 	}
-
-	return SelectResult{Name: name, Action: action}, nil
 }

--- a/internal/fzf/fzf_test.go
+++ b/internal/fzf/fzf_test.go
@@ -13,7 +13,6 @@ func TestSelfPath(t *testing.T) {
 }
 
 func TestIsAvailable(t *testing.T) {
-	// Test reflects actual system state - just verify no panic
 	available := IsAvailable()
 
 	_, err := exec.LookPath("fzf")
@@ -24,17 +23,21 @@ func TestIsAvailable(t *testing.T) {
 	}
 }
 
-func TestActionConstants(t *testing.T) {
-	if ActionNone != 0 {
-		t.Errorf("ActionNone = %d, want 0", ActionNone)
+func TestActionFromKey(t *testing.T) {
+	tests := []struct {
+		key  string
+		want Action
+	}{
+		{"ctrl-e", ActionEdit},
+		{"ctrl-d", ActionDelete},
+		{"", ActionShow},
+		{"enter", ActionShow},
 	}
-	if ActionShow != 1 {
-		t.Errorf("ActionShow = %d, want 1", ActionShow)
-	}
-	if ActionEdit != 2 {
-		t.Errorf("ActionEdit = %d, want 2", ActionEdit)
-	}
-	if ActionDelete != 3 {
-		t.Errorf("ActionDelete = %d, want 3", ActionDelete)
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			if got := actionFromKey(tt.key); got != tt.want {
+				t.Errorf("actionFromKey(%q) = %d, want %d", tt.key, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/pager/pager.go
+++ b/internal/pager/pager.go
@@ -17,7 +17,7 @@ func appendLessEnv(env []string) []string {
 			return env
 		}
 	}
-	return append(env, "LESS=FRX")
+	return append(env, "LESS=RX")
 }
 
 // IsPiped returns true if stdout is piped (not a terminal).

--- a/internal/pager/pager_test.go
+++ b/internal/pager/pager_test.go
@@ -3,6 +3,7 @@ package pager
 import (
 	"bytes"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -11,17 +12,9 @@ func TestAppendLessEnv_NotSet(t *testing.T) {
 	env := []string{"HOME=/home/user", "PATH=/usr/bin"}
 	result := appendLessEnv(env)
 
-	found := false
-	for _, e := range result {
-		if e == "LESS=FRX" {
-			found = true
-			break
-		}
+	if !slices.Contains(result, "LESS=RX") {
+		t.Error("appendLessEnv did not add LESS=RX when LESS was not set")
 	}
-	if !found {
-		t.Error("appendLessEnv did not add LESS=FRX when LESS was not set")
-	}
-	// Original entries should be preserved
 	if len(result) != len(env)+1 {
 		t.Errorf("expected %d entries, got %d", len(env)+1, len(result))
 	}
@@ -34,25 +27,18 @@ func TestAppendLessEnv_AlreadySet(t *testing.T) {
 	if len(result) != len(env) {
 		t.Error("appendLessEnv should not modify env when LESS is already set")
 	}
-	// Should keep original LESS value
-	found := false
-	for _, e := range result {
-		if e == "LESS=-RS" {
-			found = true
-		}
-		if e == "LESS=FRX" {
-			t.Error("appendLessEnv overwrote existing LESS value")
-		}
-	}
-	if !found {
+	if !slices.Contains(result, "LESS=-RS") {
 		t.Error("original LESS value was lost")
+	}
+	if slices.Contains(result, "LESS=RX") {
+		t.Error("appendLessEnv overwrote existing LESS value")
 	}
 }
 
 func TestAppendLessEnv_EmptyEnv(t *testing.T) {
 	result := appendLessEnv(nil)
-	if len(result) != 1 || result[0] != "LESS=FRX" {
-		t.Errorf("appendLessEnv(nil) = %v, want [LESS=FRX]", result)
+	if len(result) != 1 || result[0] != "LESS=RX" {
+		t.Errorf("appendLessEnv(nil) = %v, want [LESS=RX]", result)
 	}
 }
 
@@ -61,17 +47,17 @@ func TestAppendLessEnv_LessEmptyValue(t *testing.T) {
 	env := []string{"LESS="}
 	result := appendLessEnv(env)
 	if len(result) != 1 {
-		t.Error("appendLessEnv should not add LESS=FRX when LESS is already set (even if empty)")
+		t.Error("appendLessEnv should not add LESS=RX when LESS is already set (even if empty)")
 	}
 }
 
-func TestShow_NoPager(t *testing.T) {
-	// Capture stdout
+// captureShow calls Show with usePager=false and captures its stdout output.
+func captureShow(t *testing.T, content string) string {
+	t.Helper()
 	old := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	content := "test content\n"
 	err := Show(content, false)
 
 	w.Close()
@@ -83,56 +69,34 @@ func TestShow_NoPager(t *testing.T) {
 
 	var buf bytes.Buffer
 	buf.ReadFrom(r)
-	if buf.String() != content {
-		t.Errorf("Show output = %q, want %q", buf.String(), content)
+	return buf.String()
+}
+
+func TestShow_NoPager(t *testing.T) {
+	content := "test content\n"
+	got := captureShow(t, content)
+	if got != content {
+		t.Errorf("Show output = %q, want %q", got, content)
 	}
 }
 
 func TestIsPiped(t *testing.T) {
-	// In test environment, stdout is typically piped
-	// We mainly verify it doesn't panic
+	// In test environment, stdout is typically piped.
+	// We verify it returns without panic.
 	_ = IsPiped()
 }
 
 func TestShow_EmptyContent(t *testing.T) {
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := Show("", false)
-
-	w.Close()
-	os.Stdout = old
-
-	if err != nil {
-		t.Fatalf("Show returned error: %v", err)
-	}
-
-	var buf bytes.Buffer
-	buf.ReadFrom(r)
-	if buf.String() != "" {
-		t.Errorf("Show output = %q, want empty", buf.String())
+	got := captureShow(t, "")
+	if got != "" {
+		t.Errorf("Show output = %q, want empty", got)
 	}
 }
 
 func TestShow_LargeContent(t *testing.T) {
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
 	content := strings.Repeat("line\n", 1000)
-	err := Show(content, false)
-
-	w.Close()
-	os.Stdout = old
-
-	if err != nil {
-		t.Fatalf("Show returned error: %v", err)
-	}
-
-	var buf bytes.Buffer
-	buf.ReadFrom(r)
-	if buf.String() != content {
+	got := captureShow(t, content)
+	if got != content {
 		t.Error("Show did not output all content")
 	}
 }


### PR DESCRIPTION
## Summary

- charmbracelet/glamour を導入し、ターミナル上でMarkdownを装飾付きで表示する機能を追加
- `--raw` フラグ、`CC_PLANS_RAW=1` 環境変数、パイプ出力時の自動スキップによるレンダリング制御を実装
- fzf プレビューを `cc-plans show --no-pager` 経由に変更し、プレビュー内でもレンダリングを実現
- pager 起動時に `LESS=RX` を自動設定（ユーザー設定がある場合は上書きしない、lessの場合のみ）
- 全パッケージ（renderer, config, pager, plan, fzf）のユニットテストを追加

## Test plan

- [ ] `make build` でビルド成功を確認
- [ ] `go test ./...` で全テストがパスすることを確認
- [ ] `./cc-plans show <plan名>` でレンダリング表示を確認（pagerで表示される）
- [ ] `./cc-plans show <plan名> --raw` で生Markdownが表示されることを確認
- [ ] `./cc-plans show <plan名> | cat` でパイプ時は生テキストになることを確認
- [ ] `CC_PLANS_RAW=1 ./cc-plans show <plan名>` で無効化を確認
- [ ] インタラクティブモードで Enter 後に pager でレンダリング表示されることを確認
- [ ] fzf プレビューペインでレンダリングされることを確認