### PR TITLE
feat: listコマンドのデフォルト出力を拡張

### DIFF
--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -10,8 +10,9 @@ import (
 )
 
 var (
-	listLong    bool
-	listSortMod bool
+	listLong     bool
+	listSortMod  bool
+	listNameOnly bool
 )
 
 func init() {
@@ -24,6 +25,7 @@ func init() {
 
 	listCmd.Flags().BoolVarP(&listLong, "long", "l", false, "詳細表示（更新日時、サイズ、タイトル）")
 	listCmd.Flags().BoolVarP(&listSortMod, "time", "t", false, "更新順でソート")
+	listCmd.Flags().BoolVarP(&listNameOnly, "name-only", "n", false, "名前のみ表示")
 
 	rootCmd.AddCommand(listCmd)
 }
@@ -46,14 +48,37 @@ func runList(cmd *cobra.Command, args []string) error {
 		plan.SortByName(plans)
 	}
 
+	if listNameOnly {
+		for _, p := range plans {
+			fmt.Println(p.Name)
+		}
+		return nil
+	}
+
 	if listLong {
 		return printListLong(plans)
 	}
 
+	return printListDefault(plans)
+}
+
+func printListDefault(plans []plan.Plan) error {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	for _, p := range plans {
-		fmt.Println(p.Name)
+		title := p.Title
+		if title != "" {
+			title = "  " + title
+		}
+		fmt.Fprintf(w, "%s\t%s%s\n",
+			p.ModTime.Format("2006-01-02 15:04"),
+			p.Name,
+			title,
+		)
+		if p.Preview != "" {
+			fmt.Fprintf(w, "\t\033[2m%s\033[0m\n", p.Preview)
+		}
 	}
-	return nil
+	return w.Flush()
 }
 
 func printListLong(plans []plan.Plan) error {
@@ -69,6 +94,9 @@ func printListLong(plans []plan.Plan) error {
 			p.Name,
 			title,
 		)
+		if p.Preview != "" {
+			fmt.Fprintf(w, "\t\t\t\033[2m%s\033[0m\n", p.Preview)
+		}
 	}
 	return w.Flush()
 }

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -6,6 +6,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/masato-uno/cc-plans/internal/plan"
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 )
 
@@ -26,6 +27,7 @@ func init() {
 	listCmd.Flags().BoolVarP(&listLong, "long", "l", false, "詳細表示（更新日時、サイズ、タイトル）")
 	listCmd.Flags().BoolVarP(&listSortMod, "time", "t", false, "更新順でソート")
 	listCmd.Flags().BoolVarP(&listNameOnly, "name-only", "n", false, "名前のみ表示")
+	listCmd.MarkFlagsMutuallyExclusive("long", "name-only")
 
 	rootCmd.AddCommand(listCmd)
 }
@@ -62,6 +64,13 @@ func runList(cmd *cobra.Command, args []string) error {
 	return printListDefault(plans)
 }
 
+func dimText(s string) string {
+	if isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()) {
+		return "\033[2m" + s + "\033[0m"
+	}
+	return s
+}
+
 func printListDefault(plans []plan.Plan) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	for _, p := range plans {
@@ -75,7 +84,7 @@ func printListDefault(plans []plan.Plan) error {
 			title,
 		)
 		if p.Preview != "" {
-			fmt.Fprintf(w, "\t\033[2m%s\033[0m\n", p.Preview)
+			fmt.Fprintf(w, "\t%s\n", dimText(p.Preview))
 		}
 	}
 	return w.Flush()
@@ -95,7 +104,7 @@ func printListLong(plans []plan.Plan) error {
 			title,
 		)
 		if p.Preview != "" {
-			fmt.Fprintf(w, "\t\t\t\033[2m%s\033[0m\n", p.Preview)
+			fmt.Fprintf(w, "\t\t\t%s\n", dimText(p.Preview))
 		}
 	}
 	return w.Flush()

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -14,6 +14,7 @@ type Plan struct {
 	ModTime time.Time // modification time
 	Size    int64     // file size
 	Title   string    // first # heading from file
+	Preview string   // first meaningful lines as preview
 }
 
 // extractTitle reads the first # heading from the file.
@@ -32,6 +33,33 @@ func extractTitle(path string) string {
 		}
 	}
 	return ""
+}
+
+// extractPreview reads the first meaningful lines from the file, skipping headings and blank lines.
+func extractPreview(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	const maxLines = 2
+	const maxLen = 60
+
+	var lines []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() && len(lines) < maxLines {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if len([]rune(line)) > maxLen {
+			line = string([]rune(line)[:maxLen]) + "..."
+		}
+		lines = append(lines, line)
+	}
+
+	return strings.Join(lines, " / ")
 }
 
 // SearchResult represents a search match.

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -14,52 +14,69 @@ type Plan struct {
 	ModTime time.Time // modification time
 	Size    int64     // file size
 	Title   string    // first # heading from file
-	Preview string   // first meaningful lines as preview
+	Preview string    // first meaningful lines as preview
 }
 
-// extractTitle reads the first # heading from the file.
-func extractTitle(path string) string {
+// extractMeta reads the title and preview from a single file scan.
+func extractMeta(path string) (title, preview string) {
 	f, err := os.Open(path)
 	if err != nil {
-		return ""
+		return "", ""
 	}
 	defer f.Close()
 
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if strings.HasPrefix(line, "# ") {
-			return strings.TrimPrefix(line, "# ")
-		}
-	}
-	return ""
-}
-
-// extractPreview reads the first meaningful lines from the file, skipping headings and blank lines.
-func extractPreview(path string) string {
-	f, err := os.Open(path)
-	if err != nil {
-		return ""
-	}
-	defer f.Close()
-
-	const maxLines = 2
+	const maxPreviewLines = 2
 	const maxLen = 60
 
 	var lines []string
 	scanner := bufio.NewScanner(f)
-	for scanner.Scan() && len(lines) < maxLines {
+	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
+
+		if title == "" && strings.HasPrefix(line, "# ") {
+			title = strings.TrimPrefix(line, "# ")
 			continue
 		}
+
+		if len(lines) >= maxPreviewLines {
+			break
+		}
+
+		if isSkippableLine(line) {
+			continue
+		}
+
 		if len([]rune(line)) > maxLen {
 			line = string([]rune(line)[:maxLen]) + "..."
 		}
 		lines = append(lines, line)
 	}
 
-	return strings.Join(lines, " / ")
+	preview = strings.Join(lines, " / ")
+	return title, preview
+}
+
+// isSkippableLine returns true for lines that should not appear in preview.
+func isSkippableLine(line string) bool {
+	if line == "" {
+		return true
+	}
+	// headings
+	if strings.HasPrefix(line, "#") {
+		return true
+	}
+	// table separator (e.g. |---|---|)
+	trimmed := strings.ReplaceAll(strings.ReplaceAll(line, "-", ""), "|", "")
+	trimmed = strings.ReplaceAll(trimmed, ":", "")
+	trimmed = strings.TrimSpace(trimmed)
+	if trimmed == "" && strings.Contains(line, "|") {
+		return true
+	}
+	// table header rows (e.g. | Name | Value |)
+	if strings.HasPrefix(line, "|") && strings.HasSuffix(line, "|") {
+		return true
+	}
+	return false
 }
 
 // SearchResult represents a search match.

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestExtractTitle(t *testing.T) {
+func TestExtractMeta_Title(t *testing.T) {
 	dir := t.TempDir()
 
 	tests := []struct {
@@ -57,17 +57,74 @@ func TestExtractTitle(t *testing.T) {
 			if err := os.WriteFile(path, []byte(tt.content), 0644); err != nil {
 				t.Fatal(err)
 			}
-			got := extractTitle(path)
-			if got != tt.want {
-				t.Errorf("extractTitle() = %q, want %q", got, tt.want)
+			gotTitle, _ := extractMeta(path)
+			if gotTitle != tt.want {
+				t.Errorf("extractMeta() title = %q, want %q", gotTitle, tt.want)
 			}
 		})
 	}
 }
 
-func TestExtractTitle_NonexistentFile(t *testing.T) {
-	got := extractTitle("/nonexistent/path/file.md")
-	if got != "" {
-		t.Errorf("extractTitle(nonexistent) = %q, want empty", got)
+func TestExtractMeta_NonexistentFile(t *testing.T) {
+	title, preview := extractMeta("/nonexistent/path/file.md")
+	if title != "" {
+		t.Errorf("extractMeta(nonexistent) title = %q, want empty", title)
+	}
+	if preview != "" {
+		t.Errorf("extractMeta(nonexistent) preview = %q, want empty", preview)
+	}
+}
+
+func TestExtractMeta_Preview(t *testing.T) {
+	dir := t.TempDir()
+
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "basic preview",
+			content: "# Title\n\nFirst line\nSecond line\n",
+			want:    "First line / Second line",
+		},
+		{
+			name:    "skips headings and blanks",
+			content: "# Title\n\n## Section\n\nContent line\n",
+			want:    "Content line",
+		},
+		{
+			name:    "truncates long lines",
+			content: "# T\n\nあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんアイウエオカキクケコサシスセソ\n",
+			want:    "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんアイウエオカキクケコサシスセ...",
+		},
+		{
+			name:    "empty file",
+			content: "",
+			want:    "",
+		},
+		{
+			name:    "skips table rows",
+			content: "# Title\n\n| Name | Value |\n|------|-------|\n| a | b |\nReal content\n",
+			want:    "Real content",
+		},
+		{
+			name:    "max two lines",
+			content: "Line one\nLine two\nLine three\n",
+			want:    "Line one / Line two",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(dir, tt.name+".md")
+			if err := os.WriteFile(path, []byte(tt.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+			_, gotPreview := extractMeta(path)
+			if gotPreview != tt.want {
+				t.Errorf("extractMeta() preview = %q, want %q", gotPreview, tt.want)
+			}
+		})
 	}
 }

--- a/internal/plan/repository.go
+++ b/internal/plan/repository.go
@@ -56,13 +56,14 @@ func (r *Repository) List() ([]Plan, error) {
 		}
 
 		path := filepath.Join(r.plansDir, name)
+		title, preview := extractMeta(path)
 		plans = append(plans, Plan{
 			Name:    strings.TrimSuffix(name, ".md"),
 			Path:    path,
 			ModTime: info.ModTime(),
 			Size:    info.Size(),
-			Title:   extractTitle(path),
-			Preview: extractPreview(path),
+			Title:   title,
+			Preview: preview,
 		})
 	}
 

--- a/internal/plan/repository.go
+++ b/internal/plan/repository.go
@@ -62,6 +62,7 @@ func (r *Repository) List() ([]Plan, error) {
 			ModTime: info.ModTime(),
 			Size:    info.Size(),
 			Title:   extractTitle(path),
+			Preview: extractPreview(path),
 		})
 	}
 


### PR DESCRIPTION
## Summary
- `cc-plans list` のデフォルト出力に更新日時・タイトル・コンテンツプレビューを追加
- `--name-only` (`-n`) フラグを追加し、パイプ等で名前のみ取得可能に
- `-l` (long) 表示にもプレビュー行を追加
- `Plan` 構造体に `Preview` フィールドを追加し、見出し・空行をスキップした最初の2行を60文字で切り詰めて表示

## Test plan
- [ ] `go build ./cmd/cc-plans` でビルド確認
- [ ] `cc-plans list` でデフォルト出力に日時・タイトル・プレビューが表示されること
- [ ] `cc-plans list -n` で名前のみ表示されること
- [ ] `cc-plans list -l` で詳細表示にプレビューが含まれること
- [ ] `cc-plans list -t` で更新日時順ソートが動作すること
- [ ] プラン0件時のメッセージが正常に表示されること
- [ ] `go test ./...` で全テスト通過